### PR TITLE
History Explorer Coalescion

### DIFF
--- a/packages/TraceDebugger.package/Form.extension/instance/tdbContentEquals..st
+++ b/packages/TraceDebugger.package/Form.extension/instance/tdbContentEquals..st
@@ -1,0 +1,8 @@
+*TraceDebugger-UI-comparing
+tdbContentEquals: anotherObject
+
+	(self class = Form and: [anotherObject class = Form])
+		ifFalse: [^ self = anotherObject].
+	
+	^ {self width. self height. self offset. self bits}
+		= {anotherObject width. anotherObject height. anotherObject offset. anotherObject bits}

--- a/packages/TraceDebugger.package/Form.extension/methodProperties.json
+++ b/packages/TraceDebugger.package/Form.extension/methodProperties.json
@@ -2,4 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"tdbAsText" : "ct 3/21/2022 19:08" } }
+		"tdbAsText" : "ct 3/21/2022 19:08",
+		"tdbContentEquals:" : "ct 7/5/2022 16:26" } }

--- a/packages/TraceDebugger.package/Object.extension/instance/tdbContentEquals..st
+++ b/packages/TraceDebugger.package/Object.extension/instance/tdbContentEquals..st
@@ -1,0 +1,4 @@
+*TraceDebugger-UI-comparing
+tdbContentEquals: anotherObject
+
+	^ self = anotherObject

--- a/packages/TraceDebugger.package/Object.extension/methodProperties.json
+++ b/packages/TraceDebugger.package/Object.extension/methodProperties.json
@@ -6,6 +6,7 @@
 		"isTdbIsolatedError" : "ct 7/21/2022 17:23",
 		"isTdbMemorySlice" : "ct 5/12/2022 20:38",
 		"isTdbProxyHolder" : "ct 3/10/2022 22:39",
+		"tdbContentEquals:" : "ct 7/5/2022 16:24",
 		"tdbHalt" : "ct 3/19/2022 21:02",
 		"tdbIdentical:" : "ct 3/17/2022 19:15",
 		"tdbNotify:" : "ct 3/19/2022 21:02",

--- a/packages/TraceDebugger.package/TDBHistoryExplorer.class/instance/computeSliceFrom.for..st
+++ b/packages/TraceDebugger.package/TDBHistoryExplorer.class/instance/computeSliceFrom.for..st
@@ -10,6 +10,20 @@ computeSliceFrom: aStringOrText for: requestor
 	memorySlice := Cursor wait showWhile:
 		[self cursor object: self object collect: [:ea |
 			TDBMaybeResult catch: self commonErrors during: [block value: ea]]].
+	"memorySlice publicCoalesce: [:a :b | a tdbContentEquals: b]." "Depends on https://github.com/hpi-swa-lab/squeak-tracedebugger/pull/86"
+	memorySlice halt publicCoalesce: [:a :b |
+		[a hasError = b hasError
+			and: [a error = b error]
+			and:
+				[a result isForm
+					ifTrue:
+						[(a result in: [:it | {it width. it height. it depth. it bits hash}]) tdbproxyYourself
+							= (b result in: [:it | {it width. it height. it depth. it bits hash}]) tdbproxyYourself]
+					ifFalse:
+						[a tdbproxyYourself result = b tdbproxyYourself result
+							and: [a isText ==> [b isText and: [a runs hash = b runs hash]]]]]]
+			on: TDBRetracingFrayOut, (Error, Warning, Halt) do: [false]].
+	self flag: #hacked. "Compare proxies and use custom comparer for Forms/Texts etc."
 	self changed: #memorySlice.
 	
 	^ true

--- a/packages/TraceDebugger.package/TDBHistoryExplorer.class/methodProperties.json
+++ b/packages/TraceDebugger.package/TDBHistoryExplorer.class/methodProperties.json
@@ -26,7 +26,7 @@
 		"commonErrors" : "ct 7/21/2022 21:17",
 		"compileToBlock:requestor:ifFail:" : "ct 7/3/2022 21:06",
 		"completionAdditionals" : "ct 7/3/2022 22:05",
-		"computeSliceFrom:for:" : "ct 7/24/2022 00:04",
+		"computeSliceFrom:for:" : "ct 7/24/2022 22:13",
 		"contents:notifying:" : "ct 6/19/2022 00:04",
 		"context" : "ct 6/18/2022 23:32",
 		"context:" : "ct 6/18/2022 23:32",

--- a/packages/TraceDebugger.package/TDBMaybeResult.class/instance/tdbContentEquals..st
+++ b/packages/TraceDebugger.package/TDBMaybeResult.class/instance/tdbContentEquals..st
@@ -1,0 +1,6 @@
+comparing
+tdbContentEquals: anotherObject
+
+	self class = anotherObject class ifFalse: [^ false].
+	^ (self error tdbContentEquals: anotherObject error)
+		and: [self result tdbContentEquals: anotherObject result]

--- a/packages/TraceDebugger.package/TDBMaybeResult.class/methodProperties.json
+++ b/packages/TraceDebugger.package/TDBMaybeResult.class/methodProperties.json
@@ -14,4 +14,5 @@
 		"ifError:ifResult:" : "ct 6/19/2022 21:26",
 		"printOn:" : "ct 6/19/2022 21:24",
 		"result" : "ct 6/19/2022 21:14",
-		"result:" : "ct 6/19/2022 21:14" } }
+		"result:" : "ct 6/19/2022 21:14",
+		"tdbContentEquals:" : "ct 7/5/2022 16:32" } }

--- a/packages/TraceDebugger.package/TDBMemorySlice.class/instance/publicCoalesce..st
+++ b/packages/TraceDebugger.package/TDBMemorySlice.class/instance/publicCoalesce..st
@@ -1,0 +1,37 @@
+private
+publicCoalesce: equalBlock
+	"Evaluate equalBlock with each overlapping pair of the receiver's raw values. If the block answers true for a pair, replace the second one with the first one. See also #basicCondense: for preserving all values in a nested slice."
+
+	| coalescedIntervals coalescedRawValues lastInterval lastValue index |
+	coalescedIntervals := nil.
+	lastInterval := nil.
+	lastValue := Object new.
+	index := 0.
+	self timesAndValuesDo: [:interval :value |
+		(lastInterval notNil
+			and:
+				[interval isEmpty
+					or:
+						[lastInterval stop + 1 = interval start and:
+							[equalBlock value: lastValue value: value]]])
+			ifTrue:
+				[coalescedIntervals ifNil:
+					[coalescedIntervals := (Array new: intervals size) writeStream.
+					coalescedRawValues := (Array new: rawValues size) writeStream.
+					coalescedIntervals next: index putAll: intervals startingAt: 1.
+					coalescedRawValues next: index putAll: rawValues startingAt: 1].
+				lastInterval := lastInterval start to: interval stop]
+			ifFalse:
+				[lastInterval isEmptyOrNil ifFalse:
+					[coalescedIntervals ifNotNil:
+						[coalescedIntervals nextPut: lastInterval.
+						coalescedRawValues nextPut: lastValue tdbproxyYourself].
+					index := index + 1].
+				lastInterval := interval.
+				lastValue := value]].
+	coalescedIntervals ifNotNil:
+		[lastInterval isEmptyOrNil ifFalse:
+			[coalescedIntervals nextPut: lastInterval.
+			coalescedRawValues nextPut: lastValue tdbproxyYourself].
+		intervals := coalescedIntervals contents.
+		rawValues := coalescedRawValues contents].

--- a/packages/TraceDebugger.package/TDBMemorySlice.class/methodProperties.json
+++ b/packages/TraceDebugger.package/TDBMemorySlice.class/methodProperties.json
@@ -33,6 +33,7 @@
 		"pointsCollect:" : "ct 6/1/2022 19:41",
 		"postCopy" : "ct 6/1/2022 19:08",
 		"printOn:" : "ct 6/17/2022 22:03",
+		"publicCoalesce:" : "ct 7/5/2022 16:30",
 		"rangeValueAtTime:" : "ct 7/2/2022 20:23",
 		"rangeValueAtTime:ifAbsent:" : "ct 7/2/2022 20:22",
 		"rawAssociationAtTime:ifAbsent:" : "ct 6/2/2022 13:48",

--- a/packages/TraceDebugger.package/Text.extension/instance/tdbContentEquals..st
+++ b/packages/TraceDebugger.package/Text.extension/instance/tdbContentEquals..st
@@ -1,0 +1,5 @@
+*TraceDebugger-UI-comparing
+tdbContentEquals: anotherObject
+
+	self = anotherObject ifFalse: [^ false].
+	^ self runs = anotherObject runs

--- a/packages/TraceDebugger.package/Text.extension/methodProperties.json
+++ b/packages/TraceDebugger.package/Text.extension/methodProperties.json
@@ -2,4 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"tdbAsTextWithAttribute:" : "ct 3/21/2022 19:07" } }
+		"tdbAsTextWithAttribute:" : "ct 3/21/2022 19:07",
+		"tdbContentEquals:" : "ct 7/5/2022 16:33" } }


### PR DESCRIPTION
current todos and challenges:

* without https://github.com/hpi-swa-lab/squeak-tracedebugger/pull/86, we cannot compare multiple proxies on the same object for different time indices
* in general, performance! with #86, comparing two proxies would trigger simCustomizationLevel = 2! but even without that problem, it might be very slow
* more proxy problems when trying to manually compare objects (because proxies often consist of shared memory slices)
* add tests, also for publicCoalesce:, and deduplicate coalescion